### PR TITLE
Fix BSC bugs

### DIFF
--- a/docker/scout/scripts/addresses.py
+++ b/docker/scout/scripts/addresses.py
@@ -109,6 +109,14 @@ ADDRESSES_BSC = {
         "bcakebBadgerBtcb": "0x857F91f735f4B03b19D2b5c6E476C73DB8241F55",
         "bcakebDiggBtcb": "0xa861Ba302674b08f7F2F24381b705870521DDfed",
     },
+    "coingecko_tokens": {
+        "badger-dao": "0x753fbc5800a8C8e3Fb6DC6415810d627A387Dfc9",
+        "badger-sett-badger": "0x1F7216fdB338247512Ec99715587bb97BBf96eae",
+        "badger-sett-digg": "0x5986D5c77c65e5801a5cAa4fAE80089f870A71dA",
+        "binance-bitcoin": "0x7130d2A12B9BCbFAe4f2634d864A1Ee1Ce3Ead9c",
+        "binancecoin": "0xbb4cdb9cbd36b01bd1cbaebf2de08d9173bc095c",
+        "pancakeswap-token": "0x0E09FaBB73Bd3Ade0a17ECC321fD13a19e81cE82",
+    },
 }
 
 ADDRESSES_BRIDGE = {

--- a/docker/scout/scripts/data.py
+++ b/docker/scout/scripts/data.py
@@ -140,17 +140,16 @@ class Badgertree:
         return info
 
 
-def get_tokens_by_address(treasury_tokens):
-    return {
-        token_address: token_name
-        for token_name, token_address in treasury_tokens.items()
-    }
+def get_token_by_address(token_dict, query_address):
+    for token_name, token_address in token_dict.items():
+        if token_address == query_address:
+            return token_name
 
 
-def get_token_interfaces(treasury_tokens):
+def get_token_interfaces(token_dict):
     return {
         token_address: interface.ERC20(token_address)
-        for token_name, token_address in treasury_tokens.items()
+        for token_name, token_address in token_dict.items()
     }
 
 

--- a/docker/scout/scripts/main.py
+++ b/docker/scout/scripts/main.py
@@ -14,6 +14,7 @@ from scripts.data import (
     get_json_request,
     get_lp_data,
     get_sett_data,
+    get_token_by_address,
     get_token_interfaces,
     get_wallet_balances_by_token,
 )
@@ -23,6 +24,7 @@ warnings.simplefilter("ignore")
 
 PROMETHEUS_PORT = 8801
 
+NETWORK = "ETH"
 ETHNODEURL = os.environ["ETHNODEURL"]
 w3 = Web3(Web3.HTTPProvider(ETHNODEURL))
 
@@ -42,35 +44,62 @@ oracles = ADDRESSES["oracles"]
 usd_prices_by_token_address = {}
 
 
-def get_token_prices(treasury_tokens, token_csv, countertoken_csv):
+def get_token_prices(token_csv, countertoken_csv, network):
     log.info("Fetching token prices from CoinGecko ...")
-    token_prices = get_json_request(
-        request_type="get",
-        url=f"https://api.coingecko.com/api/v3/simple/token_price/ethereum?contract_addresses={token_csv}&vs_currencies={countertoken_csv}",
-    )
+
+    if network == "ETH":
+        # fetch prices by token_address on ETH
+        url = f"https://api.coingecko.com/api/v3/simple/token_price/ethereum?contract_addresses={token_csv}&vs_currencies={countertoken_csv}"
+    elif network == "BSC":
+        # fetch prices by coingecko_name on BSC
+        url = f"https://api.coingecko.com/api/v3/simple/price?ids={token_csv}&vs_currencies={countertoken_csv}"
+    else:
+        log.error(
+            "Specify network in order to fetch prices using appropriate CoinGecko API endpoint"
+        )
+
+    token_prices = get_json_request(request_type="get", url=url)
     return token_prices
 
 
 def update_price_gauge(
-    coingecko_price_gauge, token_prices, token_name, token_address, countertoken_csv
+    coingecko_price_gauge,
+    treasury_tokens,
+    token_prices,
+    token_name,
+    token_address,
+    countertoken_csv,
+    network,
 ):
     lp_prefixes = ("uni", "slp", "crv", "cake")
 
+    # BSC token_names are coingecko_names, so lookup token symbol from treasury_tokens
+    fetched_name = get_token_by_address(treasury_tokens, token_address)
+
     try:
-        if not token_name.startswith(lp_prefixes):
+        if not fetched_name.startswith(lp_prefixes):
             log.info(
-                f"Processing CoinGecko price for [bold]{token_name}: {token_address} ..."
+                f"Processing CoinGecko price for [bold]{fetched_name}: {token_address} ..."
             )
 
-            price = token_prices[token_address.lower()]
+            if network == "ETH":
+                price_key = token_address.lower()
+            elif network == "BSC":
+                price_key = token_name
+            else:
+                log.error(
+                    "Specify network in order to appropriately process CoinGecko prices"
+                )
+
+            price = token_prices[price_key]
 
             for countertoken in countertoken_csv.split(","):
                 coingecko_price_gauge.labels(
                     "ETH"
-                    if token_name == "WETH"
+                    if fetched_name == "WETH"
                     else "BNB"
-                    if token_name == "WBNB"
-                    else token_name,
+                    if fetched_name == "WBNB"
+                    else fetched_name,
                     countertoken,
                     token_address,
                 ).set(price[countertoken])
@@ -78,13 +107,14 @@ def update_price_gauge(
             usd_prices_by_token_address[token_address] = price["usd"]
         else:
             log.info(
-                f"Skipping CoinGecko price for [bold]{token_name}: {token_address} ..."
+                f"Skipping CoinGecko price for [bold]{fetched_name}: {token_address} ..."
             )
     except Exception as e:
         log.warning(
-            f"Error getting CoinGecko price for [bold]{token_name}: {token_address}"
+            f"Error getting CoinGecko price for [bold]{fetched_name}: {token_address}"
         )
         log.debug(e)
+        log.debug(token_prices, token_name, fetched_name, token_address)
 
 
 def update_digg_gauge(digg_gauge, digg_prices, slpWbtcDigg, uniWbtcDigg):
@@ -110,7 +140,7 @@ def update_digg_gauge(digg_gauge, digg_prices, slpWbtcDigg, uniWbtcDigg):
     digg_gauge.labels("sushiswap").set(digg_sushi_price)
 
 
-def update_lp_tokens_gauge(lp_tokens_gauge, lp_token, token_interfaces):
+def update_lp_tokens_gauge(lp_tokens_gauge, lp_tokens, lp_token, token_interfaces):
     lp_name = lp_token.name
     lp_address = lp_tokens[lp_name]
 
@@ -169,7 +199,7 @@ def update_crv_tokens_gauge(crv_tokens_gauge, pool_name, pool_address):
     usd_prices_by_token_address[pool_token_address] = usd_price
 
 
-def update_sett_gauge(sett_gauge, sett):
+def update_sett_gauge(sett_gauge, sett, sett_vaults, treasury_tokens):
     sett_name = sett.name
     sett_address = sett_vaults[sett_name]
     sett_token_name = sett_name[1:]
@@ -195,7 +225,12 @@ def update_sett_gauge(sett_gauge, sett):
 
 
 def update_wallets_gauge(
-    wallets_gauge, wallet_balances_by_token, token_name, token_address
+    wallets_gauge,
+    wallet_balances_by_token,
+    token_name,
+    token_address,
+    treasury_tokens,
+    network,
 ):
     log.info(f"Processing wallet balances for [bold]{token_name}: {token_address} ...")
 
@@ -209,31 +244,38 @@ def update_wallets_gauge(
             wallet_address,
         ) = wallet.values()
 
+        eth_name = "ETH" if network == "ETH" else "BNB"
+        eth_address = treasury_tokens[f"W{eth_name}"]
         eth_balance = float(w3.fromWei(w3.eth.getBalance(wallet_address), "ether"))
 
         wallets_gauge.labels(
             wallet_name, wallet_address, token_name, token_address, "balance"
         ).set(token_balance)
-        wallets_gauge.labels(wallet_name, wallet_address, "ETH", "None", "balance").set(
-            eth_balance
-        )
+        wallets_gauge.labels(
+            wallet_name, wallet_address, eth_name, "None", "balance"
+        ).set(eth_balance)
 
         try:
             wallets_gauge.labels(
                 wallet_name, wallet_address, token_name, token_address, "usdBalance"
             ).set(token_balance * usd_prices_by_token_address[token_address])
             wallets_gauge.labels(
-                wallet_name, wallet_address, "ETH", "none", "usdBalance"
-            ).set(eth_balance * usd_prices_by_token_address[treasury_tokens["WETH"]])
+                wallet_name, wallet_address, eth_name, "none", "usdBalance"
+            ).set(eth_balance * usd_prices_by_token_address[eth_address])
         except Exception as e:
             log.warning(
                 f"Error calculating USD balances for wallet [bold]{wallet_name}"
             )
             log.debug(e)
+            log.warning(eth_name, eth_address)
 
 
 def update_xchain_bridge_gauge(
-    xchain_bridge_gauge, custodian_name, custodian_address, token_interfaces
+    xchain_bridge_gauge,
+    custodian_name,
+    custodian_address,
+    token_interfaces,
+    treasury_tokens,
 ):
     log.info(
         f"Checking balances on bridge [bold]{custodian_name}: {custodian_address} ..."
@@ -254,7 +296,7 @@ def update_xchain_bridge_gauge(
         )
 
 
-def update_rewards_gauge(rewards_gauge, badgertree, badger, digg):
+def update_rewards_gauge(rewards_gauge, badgertree, badger, digg, treasury_tokens):
     log.info(f"Calculating Badgertree reward holdings ...")
 
     badger_rewards = badger.balanceOf(badgertree.address) / 1e18
@@ -374,14 +416,16 @@ def main():
         block_gauge.set(block.number)
 
         # process token prices
-        token_prices = get_token_prices(treasury_tokens, token_csv, countertoken_csv)
+        token_prices = get_token_prices(token_csv, countertoken_csv, NETWORK)
         for token_name, token_address in treasury_tokens.items():
             update_price_gauge(
                 coingecko_price_gauge,
+                treasury_tokens,
                 token_prices,
                 token_name,
                 token_address,
                 countertoken_csv,
+                NETWORK,
             )
 
         # process digg oracle prices
@@ -389,7 +433,9 @@ def main():
 
         # process lp data
         for lp_token in lp_data:
-            update_lp_tokens_gauge(lp_tokens_gauge, lp_token, token_interfaces)
+            update_lp_tokens_gauge(
+                lp_tokens_gauge, lp_tokens, lp_token, token_interfaces
+            )
 
         # process curve pool data
         for pool_name, pool_address in crv_pools.items():
@@ -397,24 +443,33 @@ def main():
 
         # process sett data
         for sett in sett_data:
-            update_sett_gauge(sett_gauge, sett)
+            update_sett_gauge(sett_gauge, sett, sett_vaults, treasury_tokens)
 
         # process wallet balances for *one* treasury token
         token_name, token_address = list(treasury_tokens.items())[
             step % num_treasury_tokens
         ]
         update_wallets_gauge(
-            wallets_gauge, wallet_balances_by_token, token_name, token_address
+            wallets_gauge,
+            wallet_balances_by_token,
+            token_name,
+            token_address,
+            treasury_tokens,
+            NETWORK,
         )
 
         # process bridged tokens
         for custodian_name, custodian_address in custodians.items():
             update_xchain_bridge_gauge(
-                xchain_bridge_gauge, custodian_name, custodian_address, token_interfaces
+                xchain_bridge_gauge,
+                custodian_name,
+                custodian_address,
+                token_interfaces,
+                treasury_tokens,
             )
 
         # process rewards balances
-        update_rewards_gauge(rewards_gauge, badgertree, badger, digg)
+        update_rewards_gauge(rewards_gauge, badgertree, badger, digg, treasury_tokens)
 
         # process badgertree cycles
         last_cycle_unixtime = badgertree_cycles.describe()


### PR DESCRIPTION
- Fix CoinGecko `get_token_prices` to use correct API endpoint depending
on specified network. Fix `update_price_gauge` to correctly process
endpoint results depending on specified network.
- Fix `update_*_gauge` functions to explicitly pass global vars so that
they run correctly when imported in BSC scripts.