### PR TITLE
Scout off chain separate process

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -39,6 +39,16 @@ services:
       - "8801"
     environment:
       - ETHNODEURL
+  scout-off-chain:
+    build:
+      context: ./scout
+    container_name: scout-off-chain
+    ports:
+      - "8801"
+    environment:
+      - ETHNODEURL
+    entrypoint:
+      - "./startOffChain.sh"
   renderer:
     image: grafana/grafana-image-renderer:latest
     ports:

--- a/docker/grafana/dashboards/homepage.json
+++ b/docker/grafana/dashboards/homepage.json
@@ -118,6 +118,66 @@
           },
           "mappings": [],
           "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "percent"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 19,
+        "x": 0,
+        "y": 8
+      },
+      "id": 37,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "text": {},
+        "textMode": "auto"
+      },
+      "pluginVersion": "8.0.6",
+      "targets": [
+        {
+          "exemplar": true,
+          "expr": "sum by (sett) (settRoi{param=\"cvxROI\", chain=\"ETH\"})",
+          "interval": "",
+          "legendFormat": "{{sett}}",
+          "refId": "A"
+        }
+      ],
+      "title": "CRV Setts data from Convex",
+      "type": "stat"
+    },
+    {
+      "datasource": null,
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
             "mode": "percentage",
             "steps": [
               {
@@ -134,7 +194,7 @@
         "h": 9,
         "w": 12,
         "x": 0,
-        "y": 8
+        "y": 15
       },
       "id": 29,
       "options": {
@@ -193,7 +253,7 @@
         "h": 5,
         "w": 7,
         "x": 12,
-        "y": 8
+        "y": 15
       },
       "id": 32,
       "options": {
@@ -252,7 +312,7 @@
         "h": 4,
         "w": 7,
         "x": 12,
-        "y": 13
+        "y": 20
       },
       "id": 33,
       "options": {
@@ -346,7 +406,7 @@
         "h": 10,
         "w": 7,
         "x": 0,
-        "y": 17
+        "y": 24
       },
       "id": 31,
       "options": {
@@ -431,7 +491,7 @@
         "h": 10,
         "w": 6,
         "x": 7,
-        "y": 17
+        "y": 24
       },
       "id": 34,
       "options": {
@@ -516,7 +576,7 @@
         "h": 10,
         "w": 6,
         "x": 13,
-        "y": 17
+        "y": 24
       },
       "id": 35,
       "options": {
@@ -561,7 +621,7 @@
         "h": 7,
         "w": 19,
         "x": 0,
-        "y": 27
+        "y": 34
       },
       "id": 25,
       "options": {
@@ -630,7 +690,7 @@
         "h": 3,
         "w": 9,
         "x": 0,
-        "y": 34
+        "y": 41
       },
       "id": 8,
       "links": [
@@ -691,7 +751,7 @@
         "h": 3,
         "w": 10,
         "x": 9,
-        "y": 34
+        "y": 41
       },
       "id": 4,
       "options": {
@@ -755,7 +815,7 @@
         "h": 9,
         "w": 19,
         "x": 0,
-        "y": 37
+        "y": 44
       },
       "hiddenSeries": false,
       "id": 6,
@@ -923,7 +983,7 @@
         "h": 8,
         "w": 13,
         "x": 0,
-        "y": 46
+        "y": 53
       },
       "hiddenSeries": false,
       "id": 18,
@@ -1049,7 +1109,7 @@
         "h": 8,
         "w": 6,
         "x": 13,
-        "y": 46
+        "y": 53
       },
       "id": 27,
       "options": {
@@ -1146,7 +1206,7 @@
         "h": 8,
         "w": 19,
         "x": 0,
-        "y": 54
+        "y": 61
       },
       "hiddenSeries": false,
       "id": 10,
@@ -1278,7 +1338,7 @@
         "h": 13,
         "w": 19,
         "x": 0,
-        "y": 62
+        "y": 69
       },
       "id": 12,
       "options": {

--- a/docker/grafana/dashboards/homepage.json
+++ b/docker/grafana/dashboards/homepage.json
@@ -159,7 +159,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "sum by (sett) (settRoi{targetChain=\"ETH\", param=\"ROI\"})",
+          "expr": "sum by (sett) (settRoi{chain=\"ETH\", param=\"ROI\"})",
           "interval": "",
           "legendFormat": "{{sett}}",
           "refId": "A"
@@ -218,7 +218,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "sum by (sett) (settRoi{targetChain=\"ARB\", param=\"ROI\"})",
+          "expr": "sum by (sett) (settRoi{chain=\"ARB\", param=\"ROI\"})",
           "interval": "",
           "legendFormat": "{{sett}}",
           "refId": "A"
@@ -277,7 +277,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "sum by (sett) (settRoi{targetChain=\"POLYGON\", param=\"ROI\"})",
+          "expr": "sum by (sett) (settRoi{chain=\"POLYGON\", param=\"ROI\"})",
           "interval": "",
           "legendFormat": "{{sett}}",
           "refId": "A"
@@ -362,7 +362,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "sum by (sett) (settRoi{targetChain=\"ETH\", param=\"ROI\"})",
+          "expr": "sum by (sett) (settRoi{chain=\"ETH\", param=\"ROI\"})",
           "interval": "",
           "legendFormat": "{{sett}}",
           "refId": "A"
@@ -447,7 +447,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "sum by (sett) (settRoi{targetChain=\"POLYGON\", param=\"ROI\"})",
+          "expr": "sum by (sett) (settRoi{chain=\"POLYGON\", param=\"ROI\"})",
           "interval": "",
           "legendFormat": "{{sett}}",
           "refId": "A"
@@ -532,7 +532,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "sum by (sett) (settRoi{targetChain=\"ARB\", param=\"ROI\"})",
+          "expr": "sum by (sett) (settRoi{chain=\"ARB\", param=\"ROI\"})",
           "interval": "",
           "legendFormat": "{{sett}}",
           "refId": "A"
@@ -1330,7 +1330,7 @@
     "list": []
   },
   "time": {
-    "from": "now-15m",
+    "from": "now-5m",
     "to": "now"
   },
   "timepicker": {},

--- a/docker/prometheus/prometheus.yml
+++ b/docker/prometheus/prometheus.yml
@@ -26,6 +26,9 @@ scrape_configs:
       - targets: ["scout-collector:8801"]
         labels:
           chain: "ETH"
+  - job_name: "scout-off-chain"
+    static_configs:
+      - targets: [ "scout-off-chain:8801" ]
   - job_name: "arb-scout"
     static_configs:
       - targets: ["arb-collector:8801"]

--- a/docker/scout/scripts/data.py
+++ b/docker/scout/scripts/data.py
@@ -338,6 +338,35 @@ def get_wallet_balances_by_token(wallets, tokens):
     }
 
 
+CVX_GRAPH_QUERY = """{
+  platforms(first: 5) {
+    id
+    curvePools {
+      name,
+      swap,
+      lpToken,
+      token,
+      gauge,
+      cvxApr,
+    }
+  }
+}
+"""
+
+
+def get_apr_from_convex() -> Optional[List[Dict]]:
+    result = requests.post(
+        'https://api.thegraph.com/subgraphs/name/convex-community/curve-pools',
+        json={'query': CVX_GRAPH_QUERY}
+    )
+    try:
+        result.raise_for_status()
+    except requests.exceptions.HTTPError:
+        log.error("Got error from CVX graph API}")
+        return
+    return result.json()['data']['platforms'][0]['curvePools']
+
+
 def get_sett_roi_data(network: Optional[str] = "ETH") -> Optional[List[Dict]]:
     log.info("Fetching ROI from Badger API")
     chain = MAPPING_TO_SETT_API_CHAIN_PARAM[network]

--- a/docker/scout/scripts/data.py
+++ b/docker/scout/scripts/data.py
@@ -362,7 +362,7 @@ def get_apr_from_convex() -> Optional[List[Dict]]:
     try:
         result.raise_for_status()
     except requests.exceptions.HTTPError:
-        log.error("Got error from CVX graph API}")
+        log.error("Got error from CVX graph API")
         return
     return result.json()['data']['platforms'][0]['curvePools']
 

--- a/docker/scout/scripts/main_off_chain.py
+++ b/docker/scout/scripts/main_off_chain.py
@@ -1,0 +1,50 @@
+"""
+This is module with scout scripts that doesn't require running on chain
+"""
+from time import sleep
+from typing import Dict
+from typing import List
+
+from prometheus_client import Gauge
+from prometheus_client import start_http_server  # noqa
+
+from scripts.addresses import SUPPORTED_CHAINS
+from scripts.addresses import reverse_addresses
+from scripts.data import get_sett_roi_data
+from scripts.logconf import log
+
+PROMETHEUS_PORT = 8801
+
+
+def update_setts_roi_gauge(
+        sett_roi_gauge: Gauge, sett_data: List[Dict], network: str
+) -> None:
+    reversed_addresses = reverse_addresses()[network]
+    for sett in sett_data:
+        sett_name = reversed_addresses[sett['settToken']]
+        sett_roi_gauge.labels(sett_name, "none", network, "ROI").set(sett['apr'])
+        # Gather data for each Sett source separately now
+        for source in sett['sources']:
+            sett_roi_gauge.labels(sett_name, source['name'], network, "apr").set(source['apr'])
+            sett_roi_gauge.labels(
+                sett_name, source['name'], network, "minApr"
+            ).set(source['minApr'])
+            sett_roi_gauge.labels(
+                sett_name, source['name'], network, "maxApr").set(source['maxApr'])
+
+
+def main():
+    log.info(
+        f"Starting Prometheus scout-collector server at http://localhost:{PROMETHEUS_PORT}"
+    )
+    start_http_server(PROMETHEUS_PORT)
+    badger_sett_roi_gauge = Gauge(
+        name="settRoi",
+        documentation="Badger Sett ROI data",
+        labelnames=["sett", "source", "targetChain", "param"],
+    )
+    while True:
+        for network in SUPPORTED_CHAINS:
+            setts_roi = get_sett_roi_data(network)
+            update_setts_roi_gauge(badger_sett_roi_gauge, setts_roi, network)
+        sleep(60)

--- a/docker/scout/scripts/main_off_chain.py
+++ b/docker/scout/scripts/main_off_chain.py
@@ -41,7 +41,7 @@ def main():
     badger_sett_roi_gauge = Gauge(
         name="settRoi",
         documentation="Badger Sett ROI data",
-        labelnames=["sett", "source", "targetChain", "param"],
+        labelnames=["sett", "source", "chain", "param"],
     )
     while True:
         for network in SUPPORTED_CHAINS:

--- a/docker/scout/scripts/main_off_chain.py
+++ b/docker/scout/scripts/main_off_chain.py
@@ -61,9 +61,10 @@ def update_crv_setts_roi_gauge(
     for sett_name, sett_address in CVX_ADDRESSES.items():
         for cvx_item in sett_data:
             if Web3.toChecksumAddress(cvx_item['swap']) == sett_address:
+                log.info(f"Updated CVX CRV pool {sett_name}")
                 sett_roi_gauge.labels(
                     sett_name, "none", CHAIN_ETH, "cvxROI"
-                ).set(cvx_item['cvxApr'])
+                ).set(float(cvx_item['cvxApr']) * 100)
 
 
 def update_setts_roi_gauge(

--- a/docker/scout/scripts/main_off_chain.py
+++ b/docker/scout/scripts/main_off_chain.py
@@ -33,6 +33,8 @@ CVX_ADDRESSES = {
 def update_crv_setts_roi_gauge(
     sett_roi_gauge: Gauge, sett_data: List[Dict]
 ):
+    if not sett_data:
+        return
     for sett_name, sett_address in CVX_ADDRESSES.items():
         for cvx_item in sett_data:
             if Web3.toChecksumAddress(cvx_item['swap']) == sett_address:

--- a/docker/scout/scripts/main_off_chain.py
+++ b/docker/scout/scripts/main_off_chain.py
@@ -5,15 +5,65 @@ from time import sleep
 from typing import Dict
 from typing import List
 
+import requests
 from prometheus_client import Gauge
 from prometheus_client import start_http_server  # noqa
+from web3 import Web3
 
+from scripts.addresses import CHAIN_ETH
+from scripts.addresses import ADDRESSES_ETH
 from scripts.addresses import SUPPORTED_CHAINS
+from scripts.addresses import checksum_address_dict
 from scripts.addresses import reverse_addresses
 from scripts.data import get_sett_roi_data
 from scripts.logconf import log
 
 PROMETHEUS_PORT = 8801
+
+
+ADDRESSES = checksum_address_dict(ADDRESSES_ETH)
+# Flatten CVX dicts
+CVX_ADDRESSES = {
+    **ADDRESSES['crv_pools'],
+    **ADDRESSES['crv_3_pools'],
+    **ADDRESSES['crv_stablecoin_pools'],
+}
+
+
+CVX_GRAPH_QUERY = """{
+  platforms(first: 5) {
+    id
+    curvePools {
+      name,
+      swap,
+      lpToken,
+      token,
+      gauge,
+      cvxApr,
+    }
+  }
+}
+"""
+
+
+def get_apr_from_convex() -> List[Dict]:
+    result = requests.post(
+        'https://api.thegraph.com/subgraphs/name/convex-community/curve-pools',
+        json={'query': CVX_GRAPH_QUERY}
+    )
+    result.raise_for_status()
+    return result.json()['data']['platforms'][0]['curvePools']
+
+
+def update_crv_setts_roi_gauge(
+    sett_roi_gauge: Gauge, sett_data: List[Dict]
+):
+    for sett_name, sett_address in CVX_ADDRESSES.items():
+        for cvx_item in sett_data:
+            if Web3.toChecksumAddress(cvx_item['swap']) == sett_address:
+                sett_roi_gauge.labels(
+                    sett_name, "none", CHAIN_ETH, "cvxROI"
+                ).set(cvx_item['cvxApr'])
 
 
 def update_setts_roi_gauge(
@@ -47,4 +97,7 @@ def main():
         for network in SUPPORTED_CHAINS:
             setts_roi = get_sett_roi_data(network)
             update_setts_roi_gauge(badger_sett_roi_gauge, setts_roi, network)
+        # Get data from convex to compare it to data from Badger API
+        crvcvx_pools_data = get_apr_from_convex()
+        update_crv_setts_roi_gauge(badger_sett_roi_gauge, crvcvx_pools_data)
         sleep(60)

--- a/docker/scout/scripts/main_off_chain.py
+++ b/docker/scout/scripts/main_off_chain.py
@@ -5,16 +5,16 @@ from time import sleep
 from typing import Dict
 from typing import List
 
-import requests
 from prometheus_client import Gauge
 from prometheus_client import start_http_server  # noqa
 from web3 import Web3
 
-from scripts.addresses import CHAIN_ETH
 from scripts.addresses import ADDRESSES_ETH
+from scripts.addresses import CHAIN_ETH
 from scripts.addresses import SUPPORTED_CHAINS
 from scripts.addresses import checksum_address_dict
 from scripts.addresses import reverse_addresses
+from scripts.data import get_apr_from_convex
 from scripts.data import get_sett_roi_data
 from scripts.logconf import log
 
@@ -28,31 +28,6 @@ CVX_ADDRESSES = {
     **ADDRESSES['crv_3_pools'],
     **ADDRESSES['crv_stablecoin_pools'],
 }
-
-
-CVX_GRAPH_QUERY = """{
-  platforms(first: 5) {
-    id
-    curvePools {
-      name,
-      swap,
-      lpToken,
-      token,
-      gauge,
-      cvxApr,
-    }
-  }
-}
-"""
-
-
-def get_apr_from_convex() -> List[Dict]:
-    result = requests.post(
-        'https://api.thegraph.com/subgraphs/name/convex-community/curve-pools',
-        json={'query': CVX_GRAPH_QUERY}
-    )
-    result.raise_for_status()
-    return result.json()['data']['platforms'][0]['curvePools']
 
 
 def update_crv_setts_roi_gauge(

--- a/docker/scout/startOffChain.sh
+++ b/docker/scout/startOffChain.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+brownie networks add Ethereum eth_mock host=$ETHNODEURL chainid=1
+exec brownie run main_off_chain --network eth_mock

--- a/terraform/aws/scout-prometheus.tf
+++ b/terraform/aws/scout-prometheus.tf
@@ -38,7 +38,7 @@ module "prometheus-container-definition" {
   container_name               = "prometheus"
   container_memory_reservation = 250
   essential                    = true
-  links = ["scout-collector", "arb-collector"]
+  links = ["scout-collector", "arb-collector", "scout-off-chain"]
   mount_points = [
     {
       containerPath = "/prometheus"
@@ -84,6 +84,29 @@ module "arb-scout-container-definition" {
       name      = "ARBNODEURL"
       valueFrom = var.arbnode_url_ssm_parameter_name
     }]
+}
+module "scout-container-off-chain-definition" {
+  source                       = "cloudposse/ecs-container-definition/aws"
+  version                      = "0.47.0"
+  container_image              = local.scout_docker_image
+  container_name               = "scout-off-chain"
+  essential                    = true
+  container_memory_reservation = 250
+  entrypoint = ["./startOffChain.sh"]
+  log_configuration = {
+    logDriver = "awslogs"
+    options = {
+      awslogs-group         = aws_cloudwatch_log_group.scout.id
+      awslogs-region        = var.region
+      awslogs-stream-prefix = "scout-off-chain"
+    }
+  }
+
+  secrets = [
+    {
+      name      = "ETHNODEURL"
+      valueFrom = var.ethnode_url_ssm_parameter_name
+  }]
 }
 module "scout-bridge-definition" {
   source                       = "cloudposse/ecs-container-definition/aws"


### PR DESCRIPTION
As requested by @Tritium-VLK, moving ROI fetch functionality to separate docker container.
Also:
1. Setting properly `chain` label to `settRoi` gauge, so no need to use `targetChain` option
2. Updated dashboard with new `chain` label
3. Updated tf configs
4. Added cvx data for ROI values
5. Added new graphana stats to dashboard for cvx ROI stats
![Screenshot 2021-11-06 at 21 32 49](https://user-images.githubusercontent.com/7059697/140621677-dac6e011-dc61-47a8-b0b4-ba8eaf67445b.png)
