### PR TITLE
Skip empty sett_roi payload in case badger API returns error

### DIFF
--- a/docker/scout/scripts/main_off_chain.py
+++ b/docker/scout/scripts/main_off_chain.py
@@ -74,6 +74,8 @@ def main():
     while True:
         for network in SUPPORTED_CHAINS:
             setts_roi = get_sett_roi_data(network)
+            if not setts_roi:
+                continue
             update_setts_roi_gauge(badger_sett_roi_gauge, setts_roi, network)
         # Get data from convex to compare it to data from Badger API
         crvcvx_pools_data = get_apr_from_convex()


### PR DESCRIPTION
Happens that badger API returns error which makes the whole off-chain process to quite.
This PR fixes that by skipping empty API response